### PR TITLE
Only adjust 'highlight' when the conceal feature isn't supported

### DIFF
--- a/autoload/AnsiEsc.vim
+++ b/autoload/AnsiEsc.vim
@@ -61,7 +61,9 @@ fun! AnsiEsc#AnsiEsc(rebuild)
      exe 'menu '.g:DrChipTopLvlMenu.'AnsiEsc.Start<tab>:AnsiEsc		:AnsiEsc<cr>'
     endif
    endif
-   let &l:hl= s:hlkeep_{bufnr("%")}
+   if !has('conceal')
+    let &l:hl= s:hlkeep_{bufnr("%")}
+   endif
 "   call Dret("AnsiEsc#AnsiEsc")
    return
   else
@@ -1510,9 +1512,9 @@ fun! AnsiEsc#AnsiEsc(rebuild)
    hi def link ansiIgnore	ansiStop
    hi def link ansiStop		Ignore
    hi def link ansiExtended	Ignore
+   let s:hlkeep_{bufnr("%")}= &l:hl
+   exe "setlocal hl=".substitute(&hl,'8:[^,]\{-},','8:Ignore,',"")
   endif
-  let s:hlkeep_{bufnr("%")}= &l:hl
-  exe "setlocal hl=".substitute(&hl,'8:[^,]\{-},','8:Ignore,',"")
 
   " handle 3 or more element ansi escape sequences by building syntax and highlighting rules
   " specific to the current file


### PR DESCRIPTION
Prior to the conceal feature, the only way to hide the escape sequences
was by overriding the highlighting of SpecialKey, setting it to Ignore.
When conceal is supported, this is now handled automatically by
concealing the specific ANSI escape sequences.  Therefore, there's no
need to change 'highlight'.

This also means that characters like tab, carriage-return, etc. that
aren't covered by AnsiEsc will be displayed to the user, highlighted by
SpecialKey as expected (especially wrt Tab, since the user may have
configured 'listchars' to show that distinctly).

Finally, this fixes compatibility with Neovim.  'highlight' was removed
from Neovim, so the plugin was emitting errors when trying to set that
option.  However, Neovim always has the conceal feature.

Closes #11