### PR TITLE
coloring stops after re-reading file

### DIFF
--- a/autoload/AnsiEsc.vim
+++ b/autoload/AnsiEsc.vim
@@ -2260,6 +2260,16 @@ fun! s:Ansi2Gui(code)
 endfun
 
 " ---------------------------------------------------------------------
+" AnsiEsc#BufReadPost: updates ansi-escape code visualization if it was alredy
+" on for the buffer{{{2
+fun! AnsiEsc#BufReadPost()
+  let bn= bufnr("%")
+  if exists("s:AnsiEsc_enabled_{bn}") && s:AnsiEsc_enabled_{bn}
+   call AnsiEsc#AnsiEsc(1)
+  endif
+endfun
+
+" ---------------------------------------------------------------------
 "  Restore: {{{1
 let &cpo= s:keepcpo
 unlet s:keepcpo

--- a/plugin/AnsiEscPlugin.vim
+++ b/plugin/AnsiEscPlugin.vim
@@ -15,6 +15,8 @@ set cpo&vim
 "  Public Interface: {{{1
 com! -bang -nargs=0 AnsiEsc	:call AnsiEsc#AnsiEsc(<bang>0)
 
+au BufReadPost * :call AnsiEsc#BufReadPost()
+
 " DrChip Menu Support: {{{2
 if !exists('g:no_drchip_menu') && !exists('g:no_ansiesc_menu')
  if has("gui_running") && has("menu") && &go =~ 'm'


### PR DESCRIPTION
Testcase:

- open file with ANSI escape sequences
- do `:AnsiEsc`
- do `:e!`
+ coloring is absent
- do `:AnsiEsc`
+ coloring is still absent
- do `:AnsiEsc` again
+ coloring is visible again