### PR TITLE
Fix MultiElementHandler to work with non-gui terminals that have termguicolors set.

### DIFF
--- a/autoload/AnsiEsc.vim
+++ b/autoload/AnsiEsc.vim
@@ -2111,11 +2111,8 @@ fun! s:MultiElementHandler()
       continue
      elseif skip == 385
       " handling <esc>[38;5;...
-      if has("gui") && has("gui_running")
-       let fg= s:Ansi2Gui(code)
-      else
-       let fg= code
-      endif
+      let fg= code
+      let guifg= s:Ansi2Gui(code)
       let skip= 0
 "      call Decho(" 2: building code=".code." skip=".skip.": mod<".mod."> fg<".fg."> bg<".bg.">")
       continue
@@ -2127,11 +2124,8 @@ fun! s:MultiElementHandler()
       continue
      elseif skip == 485
       " handling <esc>[48;5;...
-      if has("gui") && has("gui_running")
-       let bg= s:Ansi2Gui(code)
-      else
-       let bg= code
-      endif
+      let bg= code
+      let guibg= s:Ansi2Gui(code)
       let skip= 0
 "      call Decho(" 4: building code=".code." skip=".skip.": mod<".mod."> fg<".fg."> bg<".bg.">")
       continue
@@ -2212,16 +2206,10 @@ fun! s:MultiElementHandler()
 
     " build highlighting rule
     let hirule= "hi ansiMEH".mehcnt
-    if has("gui") && has("gui_running")
-     let hirule=hirule." gui=".mod
-     if fg != ""| let hirule=hirule." guifg=".fg| endif
-     if bg != ""| let hirule=hirule." guibg=".bg| endif
-    else
-     let hirule=hirule." cterm=".mod
-     if fg != ""| let hirule=hirule." ctermfg=".fg| endif
-     if bg != ""| let hirule=hirule." ctermbg=".bg| endif
-    endif
-"    call Decho(" exe hirule: ".hirule)
+    let hirule=hirule." cterm=".mod." gui=".mod
+    if fg != ""| let hirule=hirule." ctermfg=".fg." guifg=".guifg| endif
+    if bg != ""| let hirule=hirule." ctermbg=".bg." guibg=".guibg| endif
+    "call Decho(" exe hirule: ".hirule)
     exe hirule
    endif
 


### PR DESCRIPTION
A "MultiElement", aka a color escape sequence like '\e\[38;5;123m', is used for "True color" terminals and/or GUI.

Setting the vim variable 'termguicolors' means "use gui colors also in the terminal, because I know it can handle truecolors (24bit)".

In other words, you basically always want to have termguicolors set if you are at all interested in MultiElement color escapes and are on a non-gui terminal like for example konsole (that DOES handle 24bit colors).

The way this works (setting 'termguicolors') is that of the syntax highligting rules the 'gui=<24bit color>' is used, not the 'cterm=<indexed terminal color>' (same for guifg, ctermfg, guibg and ctermbg).

It is completely safe to generate syntax rules that contain both; a GUI will use the 'gui*=' arguments, and ignore the 'cterm*=' arguments, while a non-gui terminal will use the 'cterm*=' arguments and ignore the 'gui*=' argument UNLESS termguicolors is set, of course, then it act likes a GUI in that regard.

Not that has("gui") is still 0 for non-gui terminals, even if they have termguicolors set.

The right thing to do therefore is to not test for has("gui") when dealing with color codes. One should either test if termguicolors is set, or simpler, just generate both the 'cterm*=' and 'gui*=' argument.